### PR TITLE
Use crates.io dependencies instead of github ones

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "musical_keyboard"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A small lib for converting keyboard input into musical notes."
 readme = "README.md"


### PR DESCRIPTION
In accordance with [this piston issue](https://github.com/PistonDevelopers/piston/issues/891).
